### PR TITLE
Revert "[AP-400] Add support for 64bits web apps in ARM template."

### DIFF
--- a/Azure/ARM Templates/WebAppsWithStagingSlot.json
+++ b/Azure/ARM Templates/WebAppsWithStagingSlot.json
@@ -18,10 +18,6 @@
       "type": "string",
       "defaultValue": "false"
     },
-    "webApp_use32Bits": {
-      "type": "string",
-      "defaultValue": "true"
-    },
     "appPlan_name": {
       "type": "string",
       "defaultValue": "appPlanName"
@@ -98,7 +94,7 @@
           "connectionStrings": [],
           "machineKey": null,
           "scmType": "None",
-          "use32BitWorkerProcess": "[parameters('webApp_use32Bits')]",
+          "use32BitWorkerProcess": true,
           "webSocketsEnabled": false,
           "alwaysOn": "[parameters('webApp_alwaysOn')]",
           "javaVersion": "",
@@ -248,7 +244,7 @@
           "connectionStrings": [],
           "machineKey": null,
           "scmType": "None",
-          "use32BitWorkerProcess": "[parameters('webApp_use32Bits')]",
+          "use32BitWorkerProcess": true,
           "webSocketsEnabled": false,
           "alwaysOn": "[parameters('webApp_alwaysOn')]",
           "javaVersion": "",


### PR DESCRIPTION
Reverts ayudasystems/ap-infrastructure-automation-resources#12

Causes issue with deployment blocking QA completely. Will need to be fixed and reimplemented

issue log- 
https://octopus.ayudasky.com/app#/Spaces-1/projects/ayuda-platform/releases/53970/deployments/Deployments-91154?activeTab=taskLog