### PR TITLE
ACR-840 Set remoteDebuggingVersion to VS2022

### DIFF
--- a/Azure/ARM Templates/WebApps.json
+++ b/Azure/ARM Templates/WebApps.json
@@ -78,7 +78,7 @@
           "windowsFxVersion": null,
           "requestTracingEnabled": false,
           "remoteDebuggingEnabled": false,
-          "remoteDebuggingVersion": "VS2017",
+          "remoteDebuggingVersion": "VS2022",
           "httpLoggingEnabled": false,
           "logsDirectorySizeLimit": 100,
           "detailedErrorLoggingEnabled": false,


### PR DESCRIPTION
Fix Octopus deployment issue: The parameter 'remoteDebuggingVersion' has an invalid value. Details: Supported Versions: VS2022. It was VS2017.