### PR TITLE
DEVOPG-101: fix use32Bits and alwaysOn parameters

### DIFF
--- a/Azure/ARM Templates/WebApps.json
+++ b/Azure/ARM Templates/WebApps.json
@@ -15,12 +15,12 @@
       "defaultValue": "app"
     },
     "webApp_alwaysOn": {
-      "type": "bool",
-      "defaultValue": false
+      "type": "string",
+      "defaultValue": "false"
     },
     "webApp_use32Bits": {
-      "type": "bool",
-      "defaultValue": true
+      "type": "string",
+      "defaultValue": "true"
     },
     "appPlan_name": {
       "type": "string",

--- a/Azure/ARM Templates/WebAppsWithStagingSlot.json
+++ b/Azure/ARM Templates/WebAppsWithStagingSlot.json
@@ -15,12 +15,12 @@
       "defaultValue": "app"
     },
     "webApp_alwaysOn": {
-      "type": "bool",
-      "defaultValue": false
+      "type": "string",
+      "defaultValue": "false"
     },
     "webApp_use32Bits": {
-      "type": "bool",
-      "defaultValue": true
+      "type": "string",
+      "defaultValue": "true"
     },
     "appPlan_name": {
       "type": "string",

--- a/Azure/ARM Templates/WebAppsWithStagingSlotAndAppInsights.json
+++ b/Azure/ARM Templates/WebAppsWithStagingSlotAndAppInsights.json
@@ -15,12 +15,12 @@
       "defaultValue": "app"
     },
     "webApp_alwaysOn": {
-      "type": "bool",
-      "defaultValue": false
+      "type": "string",
+      "defaultValue": "false"
     },
     "webApp_use32Bits": {
-      "type": "bool",
-      "defaultValue": true
+      "type": "string",
+      "defaultValue": "true"
     },
     "appPlan_name": {
       "type": "string",


### PR DESCRIPTION
Got this from Octopus:
`Status Message: {"status":"Failed","error":{"code":"InvalidTemplate","message":"Deployment template validation failed: 'The provided value for the template parameter 'webApp_alwaysOn' is not valid. Expected a value of type 'Boolean', but received a value of type 'String'. Please see https://aka.ms/arm-create-parameter-file for usage details.'.","target":null,"details":null,"additionalInfo":[{"type":"TemplateViolation","info":{"lineNumber":18,"linePosition":20,"path":"parameters.webApp_alwaysOn.type"}}]}} `